### PR TITLE
예외 처리 추가

### DIFF
--- a/platfra/src/main/java/com/gsm/platfra/api/services/account/service/AccountService.java
+++ b/platfra/src/main/java/com/gsm/platfra/api/services/account/service/AccountService.java
@@ -5,7 +5,7 @@ import com.gsm.platfra.api.services.account.dto.GoogleLoginDto;
 import com.gsm.platfra.api.services.account.dto.LoginDto;
 import com.gsm.platfra.api.services.account.dto.SignupDto;
 import com.gsm.platfra.api.services.account.repository.TAccountRepository;
-import com.gsm.platfra.common.codes.ErrorCode;
+import com.gsm.platfra.common.codes.ErrorMessage;
 import com.gsm.platfra.system.security.provider.AuthProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,7 +26,7 @@ public class AccountService {
         TAccount tAccount = TAccountRepository.findByUserId(loginDto.userId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
         if (!passwordEncoder.matches( loginDto.password(), tAccount.getPassword())) {
             log.debug("비밀번호가 일치하지 않습니다.");
-            return ErrorCode.INVALID_PASSWORD.getMessage();
+            return ErrorMessage.INVALID_PASSWORD.getMessage();
         }
 
         String token = tokenProvider.generateAccessToken(tAccount);

--- a/platfra/src/main/java/com/gsm/platfra/common/codes/ErrorCode.java
+++ b/platfra/src/main/java/com/gsm/platfra/common/codes/ErrorCode.java
@@ -1,19 +1,18 @@
 package com.gsm.platfra.common.codes;
 
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
 
-    INVALID_PASSWORD("비밀번호가 일치하지 않습니다."),
-
+    METHOD_NOT_ALLOWED("E001"),
+    BIND_EXCEPTION("E002"),
+    DATA_INTEGRITY_VIOLATION_EXCEPTION("E003"),
     ;
 
-    private String message;
+    private final String code;
 
-    ErrorCode(String message) {
-        this.message = message;
+    ErrorCode(String code) {
+        this.code = code;
     }
 }
-

--- a/platfra/src/main/java/com/gsm/platfra/common/codes/ErrorMessage.java
+++ b/platfra/src/main/java/com/gsm/platfra/common/codes/ErrorMessage.java
@@ -1,0 +1,18 @@
+package com.gsm.platfra.common.codes;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorMessage {
+
+    INVALID_PASSWORD("비밀번호가 일치하지 않습니다."),
+
+    ;
+
+    private String message;
+
+    ErrorMessage(String message) {
+        this.message = message;
+    }
+}
+

--- a/platfra/src/main/java/com/gsm/platfra/common/exception/ExceptionResponse.java
+++ b/platfra/src/main/java/com/gsm/platfra/common/exception/ExceptionResponse.java
@@ -1,0 +1,3 @@
+package com.gsm.platfra.common.exception;
+
+public record ExceptionResponse(int status, String code, String message) { }

--- a/platfra/src/main/java/com/gsm/platfra/common/exception/GlobalExceptionHandler.java
+++ b/platfra/src/main/java/com/gsm/platfra/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,56 @@
+package com.gsm.platfra.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static com.gsm.platfra.common.codes.ErrorCode.*;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * 지원하지 않은 HTTP method 호출 할 경우 발생
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ExceptionResponse handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        log.error("HttpRequestMethodNotSupportedException", e);
+        return new ExceptionResponse(
+                HttpStatus.METHOD_NOT_ALLOWED.value(),
+                METHOD_NOT_ALLOWED.getCode(),
+                e.getMessage()
+        );
+    }
+
+    /**
+     * javax.validation.Valid 또는 @Validated binding error가 발생할 경우
+     */
+    @ExceptionHandler({BindException.class})
+    protected ExceptionResponse handleBindException(BindException e) {
+        log.error("BindException", e);
+        return new ExceptionResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                BIND_EXCEPTION.getCode(),
+                e.getMessage()
+        );
+    }
+
+    /**
+     * DB 데이터 베이스 무결성을 위반한 경우
+     */
+    @ExceptionHandler({DataIntegrityViolationException.class})
+    protected ExceptionResponse handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+        log.error("DataIntegrityViolationException", e);
+        return new ExceptionResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                DATA_INTEGRITY_VIOLATION_EXCEPTION.getCode(),
+                e.getMessage()
+        );
+    }
+
+}


### PR DESCRIPTION
- 추후 확장성을 고려해 ResponseEntity 사용하지 않았음
- ExceptionResponse 클래스를 만들어서 커스텀한 예외 처리가 가능하게 만듬
- ControllerAdvicer를 통한 전역 예외 처리

예외 코드 네이밍과 메세지는 협의 필요.

This closes #34 